### PR TITLE
Bug - Fade displays incorrect behaviour

### DIFF
--- a/Class_Rogue.cs
+++ b/Class_Rogue.cs
@@ -255,6 +255,7 @@ namespace ValheimLegends
             }            
             else if(VL_Utility.Ability2_Input_Down)
             {
+                //TODO Fix Fade behaviours
                 if (!player.GetSEMan().HaveStatusEffect("SE_VL_Ability2_CD".GetStableHashCode()))
                 {
                     if (player.GetStamina() >= VL_Utility.GetFadeCost)


### PR DESCRIPTION
This commit is not intended to be merged, but rather as a bug report, since issues seem to be disabled in this repo.
If this is done intentionally to discourage bug reports such as this one, my apologies, feel free to ignore.

There are two issues with the Rogue ability Fade, currently:

1. The ability does not trigger consistently. If you set an anchor point, walk away, and then trigger the ability again to try to teleport back to the anchor, you only succeed about 1/10 times. 9/10 times you stay in place, though you do get the fog animation.

2. If you set an anchor point on low ground and then teleport there from high ground you take the corresponding fall damage. This does not seem like the intended behavior.

Setup details
- Valheim version: 0.218.19
- Mods:
    - BepInExPack_Valheim version 5.4.2202
    - Valheim_Legends_Fork version 0.7.2
- r2modman version 3.1.49
- Steam version on Windows